### PR TITLE
Ensure pidfile is deleted on stop

### DIFF
--- a/templates/remote_syslog2.init.d.erb
+++ b/templates/remote_syslog2.init.d.erb
@@ -51,6 +51,7 @@ stop(){
       kill `cat $pid_file`
       RETVAL=$?
       echo
+      rm -f $pid_file
       return $RETVAL
     else
       echo "$pid_file not found"


### PR DESCRIPTION
The status command uses the existence of the pidfile to determine if the
service is running. The stop command only kills the pid making it so the status
command always falsely returns true since the pidfile still exists. This looks
to resolve that by deleting the pidfile on stop.

@kian 
