### PR TITLE
Ensure remote_syslog2 v0.17

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class remote_syslog2::params {
   $config_file_template    = 'remote_syslog2/log_files.yml.erb'
   $new_file_check_interval = 10
   $temp_dir                = '/tmp'
-  $version                 = 'v0.16'
+  $version                 = 'v0.17'
   $service_ensure          = 'running'
 
   case $::operatingsystem {


### PR DESCRIPTION
This ensures that remote_syslog2 is running v0.17 due to
the upstream Papertrail SSL certificate being renewed.

@kian 
